### PR TITLE
Remove lexical-binding, which is unused and implies an Emacs 24 dependency

### DIFF
--- a/osx-org-clock-menubar.el
+++ b/osx-org-clock-menubar.el
@@ -1,4 +1,4 @@
-;;; osx-org-clock-menubar.el --- simple menubar integration for org-clock  -*- lexical-binding: t; -*-
+;;; osx-org-clock-menubar.el --- simple menubar integration for org-clock
 
 ;; Copyright (C) 2015  Jordon Biondo
 


### PR DESCRIPTION
Thought I'd go ahead and add this to MELPA...
